### PR TITLE
HACK HACK HACK: get firecracker working

### DIFF
--- a/vendor/github.com/kata-containers/agent/protocols/client/client.go
+++ b/vendor/github.com/kata-containers/agent/protocols/client/client.go
@@ -101,6 +101,8 @@ func NewAgentClient(ctx context.Context, sock string, enableYamux bool) (*AgentC
 
 	ctx, cancel := context.WithTimeout(ctx, defaultDialTimeout)
 	defer cancel()
+
+	time.Sleep(1 * time.Second)
 	conn, err := grpc.DialContext(ctx, grpcAddr, dialOpts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The current shim assumes that the VM is up and running at the
time it is launched.

With firecracker we launch the VM late. So the vsock client
connection fails (and fails silently today).

This logic needs to change to wait for the VM to be actually
launched. We cannot depend on a timeout as the shim is launched
at "OCI Create" and the VM is launched at "OCI Start". And the
two commands are fully decoupled from each other.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>